### PR TITLE
Add mappable documentation pathnames

### DIFF
--- a/docs/02_playgrounds/00_index.md
+++ b/docs/02_playgrounds/00_index.md
@@ -9,4 +9,4 @@ playgrounds. Playgrounds enable visitors to quickly edit and run jsonx code in
 the browser.
 
 - [Create a new playground↩](/playgrounds)
-- [Playgrounds manual↩](/02_playgrounds/02_manual)
+- [Playgrounds manual↩](/playgrounds/manual)

--- a/docs/02_playgrounds/00_index.md
+++ b/docs/02_playgrounds/00_index.md
@@ -5,8 +5,8 @@ title: Playgrounds
 # Playgrounds
 
 You may encounter text editors across this site with a "Play" button. These are
-playgrounds. Playgrounds enable visitors to quickly edit and run jsonx code in
-the browser.
+playgrounds. Playgrounds are an interactive and fun tool enabling visitors to
+quickly edit and run jsonx code in the browser.
 
-- [Create a new playground↩](/playgrounds)
+- [Create a new playground↩](/p)
 - [Playgrounds manual↩](/playgrounds/manual)

--- a/docs/03_jsx/00_index.md
+++ b/docs/03_jsx/00_index.md
@@ -8,7 +8,7 @@ title: JSX
 >
 > JSX definition coming soon.
 
-[Learn why jsonx uses JS](/03_jsx/01_theory.md).
+[Learn why jsonx uses JS](/jsx/theory.md).
 
 ## Why does jsonx use JSX?
 

--- a/docs/04_examples/00_index.md
+++ b/docs/04_examples/00_index.md
@@ -10,4 +10,4 @@ title: Examples
 
 Learn how to use jsonx in practical situations.
 
-- [Hello world↩](/04_examples/01_hello)
+- [Hello world↩](/examples/hello)

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -10,7 +10,7 @@ import * as $api_meta from "./routes/api/meta.ts";
 import * as $api_playgrounds_id_ from "./routes/api/playgrounds/[id].ts";
 import * as $api_playgrounds_index from "./routes/api/playgrounds/index.ts";
 import * as $index from "./routes/index.ts";
-import * as $playgrounds_id_ from "./routes/playgrounds/[id].tsx";
+import * as $p_id_ from "./routes/p/[[id]].tsx";
 
 import { type Manifest } from "$fresh/server.ts";
 
@@ -24,7 +24,7 @@ const manifest = {
     "./routes/api/playgrounds/[id].ts": $api_playgrounds_id_,
     "./routes/api/playgrounds/index.ts": $api_playgrounds_index,
     "./routes/index.ts": $index,
-    "./routes/playgrounds/[id].tsx": $playgrounds_id_,
+    "./routes/p/[[id]].tsx": $p_id_,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/lib/docs/nodes.ts
+++ b/lib/docs/nodes.ts
@@ -12,8 +12,24 @@ export function sortChildren<T>(
   node: Node<T>,
   fn: (a: Node<T>, b: Node<T>) => number,
 ): void {
-  if (node.children !== undefined) {
-    node.children.sort(fn);
-    node.children.forEach((child) => sortChildren(child, fn));
+  return walkChildren(node.children ?? [], (node) => {
+    if (node.children !== undefined) {
+      node.children.sort(fn);
+    }
+  });
+}
+
+/**
+ * walkChildren walks the children of a node recursively.
+ */
+export function walkChildren<T>(
+  children: Node<T>[],
+  fn: (node: Node<T>) => void,
+): void {
+  for (const child of children) {
+    fn(child);
+    if (child.children !== undefined) {
+      walkChildren(child.children, fn);
+    }
   }
 }

--- a/lib/resources/docs.ts
+++ b/lib/resources/docs.ts
@@ -3,4 +3,6 @@ import { readFSItems } from "#/lib/docs/mod_server.ts";
 export const { items, contents, nodes } = await readFSItems({
   root: "./docs",
   isIndex: (suffix) => suffix.startsWith("00_"),
+  mapName: (name) =>
+    name.map((part) => part.replace(/^\d{2}_/, "").replace(/_/g, "-")),
 });

--- a/routes/p/[[id]].tsx
+++ b/routes/p/[[id]].tsx
@@ -1,4 +1,4 @@
-import type { FreshContext, RouteConfig } from "$fresh/server.ts";
+import type { FreshContext } from "$fresh/server.ts";
 import { Head } from "$fresh/runtime.ts";
 import { getMeta } from "#/lib/meta/meta.ts";
 import { getPlayground } from "#/lib/playgrounds/deno_kv/mod.ts";
@@ -6,13 +6,8 @@ import { kv } from "#/lib/resources/kv.ts";
 import { defaultExample } from "#/lib/resources/examples.ts";
 import PlaygroundAside from "#/components/playground_aside.tsx";
 import Playground from "#/components/playground/playground.tsx";
-import { parse } from "$std/path/parse.ts";
 import { parsePlaygroundExampleExpression } from "#/lib/playgrounds/expressions/mod.ts";
 import { readExample } from "#/lib/examples/mod.ts";
-
-export const config: RouteConfig = {
-  routeOverride: "/(p|playgrounds){/:id}?",
-};
 
 export default async function PlaygroundHandler(
   _request: Request,


### PR DESCRIPTION
### Changes

* **Clean Pathnames:** Implement cleaner documentation pathnames by using `Array.prototype.map` and node names from `"#/lib/docs/nodes.ts"` after sorting.
* **Unified Playground URLs:** Deprecate `/playgrounds` and migrate playgrounds to use `/p/:id` URLs for consistency.

### Improvements

1. **Clean Documentation Pathnames:** We'll simplify documentation pathnames to remove unnecessary prefixes. This will improve readability for users.
2. **Unified Playground URLs:** We'll switch playgrounds to use a consistent URL format (`/p/:id`). This simplifies access and reduces confusion.


Resolves #9.