### PR TITLE
Support prefers color scheme dark

### DIFF
--- a/components/doc/doc_content.tsx
+++ b/components/doc/doc_content.tsx
@@ -44,7 +44,7 @@ export default function DocContent(props: DocContentProps) {
         <meta property="og:title" content={title} />
         <link rel="stylesheet" href="/md.css" />
 
-        <Hljs id="github" />
+        <Hljs id="monokai" />
         <script src="/copy.js" defer></script>
       </Head>
 

--- a/components/doc/doc_content.tsx
+++ b/components/doc/doc_content.tsx
@@ -44,7 +44,8 @@ export default function DocContent(props: DocContentProps) {
         <meta property="og:title" content={title} />
         <link rel="stylesheet" href="/md.css" />
 
-        <Hljs id="monokai" />
+        {/* Choose an ID: https://highlightjs.org/examples */}
+        <Hljs id="github-dark-dimmed" />
         <script src="/copy.js" defer></script>
       </Head>
 

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -14,9 +14,9 @@ export interface NavProps {
 export default function Nav(props: NavProps) {
   return (
     <nav class="nav">
-      <a href="/">
-        <h1>jsonx</h1>
-      </a>
+      <h1>
+        <a href="/">jsonx</a>
+      </h1>
 
       <ToC
         nodes={nodes}

--- a/static/global.css
+++ b/static/global.css
@@ -20,6 +20,10 @@ body {
   font-size: 1.2em;
 }
 
+a:hover {
+  color: #f0a8ff;
+}
+
 .nav {
   grid-area: nav;
   margin: 0 1em;
@@ -27,6 +31,10 @@ body {
 
 .nav h1 {
   font-size: 1.5em;
+}
+
+.nav h1 a {
+  text-decoration: none;
 }
 
 .nav ul {
@@ -65,6 +73,29 @@ body {
 
 .table-of-contents ol {
   margin-left: 1em;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #111;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  a,
+  ul,
+  ol {
+    color: #eee;
+  }
+
+  a:visited {
+    color: #c671ff;
+  }
 }
 
 @media (min-width: 768px) {

--- a/static/global.css
+++ b/static/global.css
@@ -7,7 +7,7 @@
 }
 
 ::selection {
-  background-color: #f0a8ff;
+  background-color: rgba(240, 168, 255, 0.5);
 }
 
 body {
@@ -20,8 +20,12 @@ body {
   font-size: 1.2em;
 }
 
+a:visited {
+  color: #833bff;
+}
+
 a:hover {
-  color: #f0a8ff;
+  color: #e045ff;
 }
 
 .nav {
@@ -99,6 +103,10 @@ a:hover {
 
   a:visited {
     color: #c671ff;
+  }
+
+  a:hover {
+    color: #f0a8ff;
   }
 }
 

--- a/static/global.css
+++ b/static/global.css
@@ -90,7 +90,11 @@ a:hover {
   a,
   ul,
   ol {
-    color: #eee;
+    color: #ddd;
+  }
+
+  hr {
+    border-color: #333;
   }
 
   a:visited {

--- a/static/md.css
+++ b/static/md.css
@@ -74,8 +74,10 @@
 
 .markdown-body pre,
 .markdown-body code {
-  background-color: #f8f8f8;
-  border: 1px solid #ddd;
+  font-family: monospace;
+  color: #ddd;
+  background-color: #44475a;
+  border: 1px solid #282a36;
   border-radius: 3px;
   padding: 0.1em 0.2em;
 }
@@ -90,6 +92,7 @@
   overflow-x: auto;
   white-space: pre-wrap;
   word-break: break-all;
+  border: none;
 }
 
 .markdown-body pre {
@@ -103,6 +106,7 @@
   text-decoration: underline;
   text-underline-offset: 0.3em;
   padding: 0.2em 0.9em;
+  color: #bbb;
 }
 
 .markdown-body pre button {
@@ -110,6 +114,16 @@
   top: 5px;
   right: 5px;
   height: 2em;
+  color: #bbb;
+  background-color: #303241;
+}
+
+.markdown-body kbd {
+  border-radius: 3px;
+  padding: 1px 2px 0;
+  border: 1px solid black;
+  background-color: #f7f7f7;
+  font-family: monospace;
 }
 
 .markdown-body img:not(:has([width]), :has([height])) {
@@ -121,20 +135,5 @@
   .markdown-body blockquote {
     background-color: rgba(255, 255, 255, 0.1);
     border-left: 0.25em solid #44475a;
-  }
-
-  .markdown-body pre,
-  .markdown-body code {
-    background-color: #44475a;
-    border: 1px solid #282a36;
-  }
-
-  .markdown-body pre:before {
-    color: #f8f8f2;
-  }
-
-  .markdown-body pre button {
-    color: #f8f8f2;
-    background-color: #303241;
   }
 }

--- a/static/md.css
+++ b/static/md.css
@@ -1,6 +1,7 @@
 .markdown-body {
   margin: 0 auto;
   line-height: 1.5;
+  margin-bottom: 2em;
 }
 
 @media (min-width: 768px) {
@@ -114,4 +115,26 @@
 .markdown-body img:not(:has([width]), :has([height])) {
   max-width: 100%;
   height: auto;
+}
+
+@media (prefers-color-scheme: dark) {
+  .markdown-body blockquote {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-left: 0.25em solid #44475a;
+  }
+
+  .markdown-body pre,
+  .markdown-body code {
+    background-color: #44475a;
+    border: 1px solid #282a36;
+  }
+
+  .markdown-body pre:before {
+    color: #f8f8f2;
+  }
+
+  .markdown-body pre button {
+    color: #f8f8f2;
+    background-color: #303241;
+  }
 }


### PR DESCRIPTION
### Changes

- Change colors to match dark color scheme preference inside media queries, [`@media (prefers-color-scheme: dark)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).

Resolves #16.