### PR TITLE
Playgrounds: Replace Codemirror with Monaco

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -2,8 +2,6 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 
 ::selection {
@@ -18,6 +16,8 @@ body {
   grid-template-areas: "nav" "aside" "main" "foot";
   gap: 0px 0px;
   font-size: 1.2em;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
 
 a:visited {

--- a/static/global.css
+++ b/static/global.css
@@ -49,7 +49,6 @@ a:hover {
 .main {
   grid-area: main;
   padding: 0 0.7em;
-  min-height: 95vh;
 }
 
 .aside {

--- a/static/playground.css
+++ b/static/playground.css
@@ -51,12 +51,12 @@ body {
 }
 
 #editor {
-  width: 100%;
-  color: black;
-  background-color: #fff;
-  padding: 0.5em;
+  max-width: 100%;
+  height: 100%;
+  min-height: 200px;
   resize: vertical;
-  margin-bottom: -5px;
+  overflow: auto hidden;
+  color: black;
   border-radius: 0 0 0.5em 0.5em;
 }
 

--- a/static/playground.css
+++ b/static/playground.css
@@ -52,8 +52,9 @@ body {
 
 #editor {
   max-width: 100%;
-  height: 100%;
+  height: 400px;
   min-height: 200px;
+  max-height: 100vh;
   resize: vertical;
   overflow: auto hidden;
   color: black;

--- a/static/script.js
+++ b/static/script.js
@@ -76,9 +76,6 @@ function createEditor(options) {
       isChanged = true;
     }
   });
-  elements.version.addEventListener("change", () => {
-    setMonacoTSConfig(getVersion());
-  });
 }
 
 function sharePlayground() {
@@ -92,7 +89,7 @@ function sharePlayground() {
 
   const data = {
     code: getEditorCode(),
-    version: elements.version.value,
+    version: getVersion(),
   };
 
   elements.share.disabled = true;
@@ -172,7 +169,7 @@ async function handlePlay() {
 
     const transformation = await transform({
       code,
-      version: elements.version.value,
+      version: getVersion(),
     });
     transformation.warnings.forEach((warning) => {
       logBuildOutput("warning", warning.text);

--- a/static/script.js
+++ b/static/script.js
@@ -1,5 +1,5 @@
 import * as esbuild from "https://esm.sh/esbuild-wasm@0.20.1";
-import * as monaco from 'https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/+esm';
+import * as monaco from "https://cdn.jsdelivr.net/npm/monaco-editor@0.47.0/+esm";
 
 document.addEventListener("DOMContentLoaded", () => {
   const initialData = JSON.parse(elements.initialJSONData.innerHTML);
@@ -33,12 +33,35 @@ async function transform(options) {
 let monacoEditor;
 
 function createEditor(options) {
-  // https://codemirror.net/examples/styling/
-  // https://github.com/codemirror/dev/blob/ccb92f9b09ceec46caceae4fb908a83642271b4d/demo/demo.ts
- 
-  monacoEditor = monaco.editor.create(options.target);
-  monacoEditor.getModel().setValue(options.code);
-  console.log(monacoEditor);
+  monacoEditor = monaco.editor.create(
+    options.target,
+    {
+      value: options.code,
+      language: "typescript",
+      theme: "vs-dark",
+    },
+  );
+  monacoEditor.updateOptions({
+    fontSize: 16,
+    fontFamily: "Fira Code",
+  });
+
+  function handleResize() {
+    // Make the editor as small as possible.
+    monacoEditor.layout({ width: 0, height: 0 });
+
+    // Wait for last layout shift to complete.
+    requestAnimationFrame(() => {
+      const parent = elements.editor.parentElement;
+      const rect = parent.getBoundingClientRect();
+      monacoEditor.layout({ width: rect.width, height: rect.height });
+    });
+  }
+
+  // Set up event listeners.
+  globalThis.addEventListener("resize", handleResize);
+  const resizeObserver = new ResizeObserver(handleResize);
+  resizeObserver.observe(elements.editor);
 }
 
 function sharePlayground() {
@@ -130,7 +153,10 @@ async function handlePlay() {
       return;
     }
 
-    const transformation = await transform({code,version: elements.version.value});
+    const transformation = await transform({
+      code,
+      version: elements.version.value,
+    });
     transformation.warnings.forEach((warning) => {
       logBuildOutput("warning", warning.text);
     });
@@ -191,7 +217,6 @@ function appendConsoleOutput(type, message) {
 function getEditorCode() {
   return monacoEditor.getModel().getValue();
 }
-
 
 /**
  * elements of the playground.
@@ -268,7 +293,6 @@ export const elements = {
 
     return consoleDetails;
   },
-
 
   get initialJSONData() {
     const initialJSONData = document.getElementById("initialJSONData");

--- a/static/script.js
+++ b/static/script.js
@@ -31,28 +31,7 @@ async function transform(options) {
 
 let monacoEditor;
 
-function setMonacoTSConfig(version) {
-  monaco.languages.typescript.javascriptDefaults.setCompilerOptions(
-    makeTSConfig(version),
-  );
-}
-
 function createEditor(options) {
-  monaco.editor.defineTheme("jsonx", {
-    base: "vs-dark",
-    inherit: true,
-    // TODO: Figure out how to change fontFamily.
-    rules: [
-      { token: "", foreground: "#ffffff" },
-    ],
-    colors: {
-      "editor.foreground": "#ffffff",
-    },
-  });
-
-  // TODO: Figure out how to set up TypeScript intellisense.
-  setMonacoTSConfig(options.version);
-
   // TODO: Figure out how to resolve this error.
   //
   // codicon.ttf:1
@@ -61,7 +40,7 @@ function createEditor(options) {
   monacoEditor = monaco.editor.create(
     options.target,
     {
-      theme: "jsonx",
+      theme: "vs-dark",
       fontSize: 18,
       model: monaco.editor.createModel(
         options.code,
@@ -69,6 +48,7 @@ function createEditor(options) {
         monaco.Uri.parse("inmemory://model/main.tsx"),
       ),
       // TODO: Figure out how to paste content into the editor.
+      // TODO: Figure out how to change fontFamily.
     },
   );
 

--- a/static/script.js
+++ b/static/script.js
@@ -36,10 +36,13 @@ function createEditor(options) {
   monacoEditor = monaco.editor.create(
     options.target,
     {
-      value: options.code,
-      language: "typescript",
       theme: "vs-dark",
       fontSize: 18,
+      model: monaco.editor.createModel(
+        options.code,
+        "typescript",
+        monaco.Uri.parse("inmemory://model/main.tsx"),
+      ),
       // TODO: Figure out how to update fontFamily.
     },
   );

--- a/static/script.js
+++ b/static/script.js
@@ -42,6 +42,7 @@ function createEditor(options) {
     {
       theme: "vs-dark",
       fontSize: 18,
+      fontFamily: "Fira Code",
       model: monaco.editor.createModel(
         options.code,
         "typescript",
@@ -49,6 +50,9 @@ function createEditor(options) {
       ),
       // TODO: Figure out how to paste content into the editor.
       // TODO: Figure out how to change fontFamily.
+
+      // NOTE: Your global font family styles are overriding the font family set here
+      // NOTE: Pasting content into the editor is working fine on my end
     },
   );
 

--- a/static/script.js
+++ b/static/script.js
@@ -9,10 +9,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
-globalThis.onbeforeunload = () => {
-  return "";
-};
-
 async function transform(options) {
   const transformation = await esbuild.transform(options.code, {
     loader: "tsx",
@@ -43,7 +39,8 @@ function createEditor(options) {
         "typescript",
         monaco.Uri.parse("inmemory://model/main.tsx"),
       ),
-      // TODO: Figure out how to update fontFamily.
+      // TODO: Figure out how to change fontFamily.
+      // TODO: Figure out how to paste content into the editor.
     },
   );
 
@@ -62,6 +59,16 @@ function createEditor(options) {
   globalThis.addEventListener("resize", handleResize);
   const resizeObserver = new ResizeObserver(handleResize);
   resizeObserver.observe(elements.editor);
+  let isChanged = false;
+  monacoEditor.getModel().onDidChangeContent(() => {
+    if (!isChanged) {
+      globalThis.onbeforeunload = () => {
+        return "";
+      };
+
+      isChanged = true;
+    }
+  });
 }
 
 function sharePlayground() {

--- a/static/script.js
+++ b/static/script.js
@@ -39,12 +39,10 @@ function createEditor(options) {
       value: options.code,
       language: "typescript",
       theme: "vs-dark",
+      fontSize: 18,
+      // TODO: Figure out how to update fontFamily.
     },
   );
-  monacoEditor.updateOptions({
-    fontSize: 16,
-    fontFamily: "Fira Code",
-  });
 
   function handleResize() {
     // Make the editor as small as possible.
@@ -52,8 +50,7 @@ function createEditor(options) {
 
     // Wait for last layout shift to complete.
     requestAnimationFrame(() => {
-      const parent = elements.editor.parentElement;
-      const rect = parent.getBoundingClientRect();
+      const rect = elements.editor.parentElement.getBoundingClientRect();
       monacoEditor.layout({ width: rect.width, height: rect.height });
     });
   }

--- a/static/script.js
+++ b/static/script.js
@@ -48,11 +48,6 @@ function createEditor(options) {
         "typescript",
         monaco.Uri.parse("inmemory://model/main.tsx"),
       ),
-      // TODO: Figure out how to paste content into the editor.
-      // TODO: Figure out how to change fontFamily.
-
-      // NOTE: Your global font family styles are overriding the font family set here
-      // NOTE: Pasting content into the editor is working fine on my end
     },
   );
 


### PR DESCRIPTION
### Changes

- Switches playground code editor from Codemirror to Monaco.

Resolves #10.